### PR TITLE
fix: make keymaps work

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ Neovim plugin for editing Tmux configuration and scripting files. Consists large
 
 * Improved file detection
 * Incorporation of the built-in Neovim compilation tooling -- provides a `compile/` file that sets the `makeprg` and `errorformat` settings used by `:make` to call `tmux source` on the file loaded in the current buffer. A Lua funciton to do the same with the [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) Job API is included as well.
-* Key command to execute the highlighted or visually selected line(s)
-* Key command to show the man page entry for the item under the cursor in a floating window
+* Execute command under cursorline or visual select
+* Show the man page entry for the item under the cursor in a floating window
 
 ## Requirements
 
+* Neovim 0.7.0+
 * Tmux
 * [plenary.nvim](https://github.com/nvim-lua/plenary.nvim)
 
@@ -47,4 +48,13 @@ local nvim_tmux_default_configs = {
   -- :h nvim_open_win for the complete list of options.
   man_floatwin_border = "single"
 }
+```
+
+No keymaps are provided by default, but you can put the following into an `augroup` or `ftplugin/tmux.lua`:
+
+```lua
+vim.keymap.set("n", "<leader>s", "<Plug>(tmux_source_file)", { silent = true, remap = false })
+vim.keymap.set("n", "K", "<Plug>(tmux_show_man_floatwin)", { silent = true, remap = false })
+vim.keymap.set("n", "g!!", "<Plug>(tmux_execute_cursorline)", { silent = true, remap = false })
+vim.keymap.set("v", "g!", "<Plug>(tmux_execute_selection)", { silent = true, remap = false })
 ```

--- a/lua/nvim_tmux/config.lua
+++ b/lua/nvim_tmux/config.lua
@@ -1,0 +1,32 @@
+-- I just copied all of this from comment-nvim because it confuses me
+local Config = {
+  state = {},
+  config = {
+    floatwin = {
+      height = 0.85,
+      width = 0.85,
+      style = "minimal",
+      border = "single",
+    },
+  },
+}
+
+function Config:set(cfg)
+  if cfg then
+    self.config = vim.tbl_deep_extend("force", self.config, cfg)
+  end
+  return self
+end
+
+function Config:get()
+  return self.config
+end
+
+return setmetatable(Config, {
+  __index = function(this, k)
+    return this.state[k]
+  end,
+  __newindex = function(this, k, v)
+    this.state[k] = v
+  end,
+})

--- a/plugin/nvim_tmux.lua
+++ b/plugin/nvim_tmux.lua
@@ -1,22 +1,39 @@
-local K = vim.keymap.set
+if 1 ~= vim.fn.has("nvim-0.7.0") then
+  vim.api.nvim_err_writeln("nvim-tmux requires at least nvim-0.7.0.")
+  return
+end
 
-K(
+if vim.g.loaded_nvim_tmux == 1 then
+  return
+end
+vim.g.loaded_nvim_tmux = 1
+
+local nvim_tmux = require("nvim_tmux")
+
+vim.keymap.set(
   "n",
   "<Plug>(tmux_show_man_floatwin)",
-  "<CMD>lua require('tmux_nvim').tmux_show_man_floatwin()<CR>g@",
-  { desc = "Show man for term under cursor in floating window" }
+  function() nvim_tmux.show_man_floatwin() end,
+  {}
 )
 
-K(
+vim.keymap.set(
   "n",
   "<Plug>(tmux_source_file)",
-  "<CMD>lua require('tmux_nvim').tmux_source_file()<CR>g@",
+  function() vim.api.nvim_command("TmuxSource") end,
   { desc = "Tmux source file in current buffer" }
 )
 
-K(
+vim.keymap.set(
   "n",
+  "<Plug>(tmux_execute_cursorline)",
+  function() nvim_tmux.execute_cursorline() end,
+  { desc = "Tmux execute cursorline" }
+)
+
+vim.keymap.set(
+  "v",
   "<Plug>(tmux_execute_selection)",
-  "<ESC><CMD>lua require('tmux_nvim').tmux_execute_selection()<CR>",
-  { desc = "Tmux execute currently selected command(s)" }
+  function() nvim_tmux.execute_selection() end,
+  { desc = "Tmux execute selected line(s)"}
 )


### PR DESCRIPTION
close #12 

* break run selection command into different commands for cursorline and visual select
* fixes configs to retain state across multiple `require()` calls